### PR TITLE
LPS-84037 Using distinct to return just one record per structureId

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_1_3/UpgradeDDMStorageLink.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_1_3/UpgradeDDMStorageLink.java
@@ -37,7 +37,7 @@ public class UpgradeDDMStorageLink extends UpgradeProcess {
 
 		try (PreparedStatement ps1 = connection.prepareStatement(
 				StringBundler.concat(
-					"select DDMStorageLink.structureId, ",
+					"select distinct DDMStorageLink.structureId, ",
 					"TEMP_TABLE.structureVersionId from DDMStorageLink inner ",
 					"join (select structureId, max(structureVersionId) as ",
 					"structureVersionId from DDMStructureVersion group by ",


### PR DESCRIPTION
Hi @pedroqueiroz,

I think that this change will save a lot of time for cases like the explained here:
https://issues.liferay.com/browse/LPS-84037

Could you review it?

Thanks.